### PR TITLE
changed visibility to public

### DIFF
--- a/includes/classes/rest-api/controllers/v2/products/class-cocart-products-controller.php
+++ b/includes/classes/rest-api/controllers/v2/products/class-cocart-products-controller.php
@@ -541,7 +541,7 @@ class CoCart_REST_Products_V2_Controller extends CoCart_Products_Controller {
 	/**
 	 * Get variation product data.
 	 *
-	 * @access protected
+	 * @access public
 	 *
 	 * @since 3.1.0 Introduced.
 	 *
@@ -549,7 +549,7 @@ class CoCart_REST_Products_V2_Controller extends CoCart_Products_Controller {
 	 *
 	 * @return array $data Variation product details.
 	 */
-	protected function get_variation_product_data( $product ) {
+	public function get_variation_product_data( $product ) {
 		$data = self::get_product_data( $product );
 
 		$fields_not_required = array(


### PR DESCRIPTION
### Description
method is called on an instance of CoCart_Products_V2_Controller() in class-cocart-product-variations-controller.php and so should be public, not protected.
